### PR TITLE
Apply keyword replacements in reverse order

### DIFF
--- a/src/Bonsai.Scripting.Expressions.Tests/ExpressionScriptingTests.cs
+++ b/src/Bonsai.Scripting.Expressions.Tests/ExpressionScriptingTests.cs
@@ -63,6 +63,7 @@ namespace Bonsai.Scripting.Expressions.Tests
         [DataRow("guid.empty.tobytearray()[0]", 42, 0)]
         [DataRow("timespan.tickspermillisecond", 0, TimeSpan.TicksPerMillisecond)]
         [DataRow("it > 0 ? convert.toint16(it) : int16.minvalue", 42, (short)42)]
+        [DataRow("new(single(it) as X, single(it) as Y).X", 42, 42f)]
         public Task TestCasingCompatibility<TSource, TResult>(string expression, TSource value, TResult expected)
         {
             return AssertExpressionTransform(expression, value, expected);

--- a/src/Bonsai.Scripting.Expressions/CompatibilityAnalyzer.cs
+++ b/src/Bonsai.Scripting.Expressions/CompatibilityAnalyzer.cs
@@ -52,7 +52,7 @@ namespace Bonsai.Scripting.Expressions
             if (replacements?.Count > 0)
             {
                 var sb = new StringBuilder(text);
-                for (int i = 0; i < replacements.Count; i++)
+                for (int i = replacements.Count - 1; i >= 0; i--)
                 {
                     var (token, keyword) = replacements[i];
                     sb.Remove(token.Pos, token.Text.Length);


### PR DESCRIPTION
When multiple replacements are required, they must be applied in reverse order, to avoid errors caused by position offsets in other matched tokens to be replaced.